### PR TITLE
Fixes reading response data in multiple chunks

### DIFF
--- a/src/Jenkins.ts
+++ b/src/Jenkins.ts
@@ -83,6 +83,7 @@ export class Jenkins {
 
     return new Promise<JenkinsStatus>((resolve, reject) => {
 
+      let data = '';
       let statusCode: number;
       let result: JenkinsStatus;
       
@@ -91,7 +92,10 @@ export class Jenkins {
         .on('response', function(response) {
           statusCode = response.statusCode;
         })
-        .on('data', function(data) {
+        .on('data', function(chunk) {
+          data += chunk;
+        })
+        .on('end', function() {
           switch (statusCode) {
             case 200:
                 let myArr = JSON.parse(data);


### PR DESCRIPTION
This PR fixes problem with larger response from Jenkins API.
When response data are larger it is needed to read all chunks and join them before parsing the json (http://stackoverflow.com/questions/5083914/get-the-whole-response-body-when-the-response-is-chunked).

(BTW instead of `request` library I would recommend to use `axios` which uses Promise API, parses JSON by default and works well with TypeScript `async`/`await`.)