### PR TITLE
Support Basic Authentication (Issue #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ It is automatically enabled if you have a `.jenkins` file in the root folder of 
 
 ```json
 {
-    "url": "http://127.0.0.1:8080/job/myproject"
+    "url": "http://127.0.0.1:8080/job/myproject",
+    "username": "jenkinsuser",
+    "password": "jenkinspassword"
 }
 ``` 
 

--- a/src/Jenkins.ts
+++ b/src/Jenkins.ts
@@ -116,9 +116,10 @@ export class Jenkins {
                 resolve(result);
               break;
               
+            case 401:
             case 403:
               result = {
-                jobName: 'AUTENTICATION NEEDED',
+                jobName: 'AUTHENTICATION NEEDED',
                 url: url,
                 status: BuildStatus.Disabled,
                 statusName: 'Disabled',

--- a/src/Jenkins.ts
+++ b/src/Jenkins.ts
@@ -79,7 +79,7 @@ export function getConnectionStatusName(status: ConnectionStatus): string {
 export class Jenkins { 
 
 
-  public getStatus(url: string) {
+  public getStatus(url: string, username: string, password: string) {
 
     return new Promise<JenkinsStatus>((resolve, reject) => {
 
@@ -88,7 +88,12 @@ export class Jenkins {
       let result: JenkinsStatus;
       
       request
-        .get(url + '/api/json')
+        .get(url + '/api/json', {
+          'auth': {
+            'user': username,
+            'pass': password
+          }
+        })
         .on('response', function(response) {
           statusCode = response.statusCode;
         })

--- a/src/JenkinsIndicator.ts
+++ b/src/JenkinsIndicator.ts
@@ -27,9 +27,13 @@ export class JenkinsIndicator {
 
 
             let url: string;
+            let user: string;
+            let pw: string;
             let settings = JSON.parse(fs.readFileSync(path.join(vscode.workspace.rootPath, '.jenkins')).toString());
             url = settings.url;
-            
+            user = settings.username;
+            pw = settings.password;
+
             // invalid URL
             if (!url) {
                 this.statusBarItem.tooltip = 'No URL Defined';
@@ -40,7 +44,7 @@ export class JenkinsIndicator {
                 return;
             }            
         
-            jjj.getStatus(url)
+            jjj.getStatus(url, user, pw)
                 .then((status) => {
 
                     let icon: string;

--- a/src/JenkinsIndicator.ts
+++ b/src/JenkinsIndicator.ts
@@ -31,8 +31,8 @@ export class JenkinsIndicator {
             let pw: string;
             let settings = JSON.parse(fs.readFileSync(path.join(vscode.workspace.rootPath, '.jenkins')).toString());
             url = settings.url;
-            user = settings.username;
-            pw = settings.password;
+            user = settings.username ? settings.username : "";
+            pw = settings.password ? settings.password : "";
 
             // invalid URL
             if (!url) {


### PR DESCRIPTION
First of all, thanks for putting this out here! 

**New Functionality**

Users may now provide a `username` and `password` in their `.jenkins` file, and connect to a secured Jenkins instance.

**Acceptance criteria:**

Existing users who connect to an unsecured Jenkins instance should be unaffected.  They will not have to modify their `.jenkins` file, and things will continue to work as they have.

Users wishing to connect to a secured Jenkins instance can simply add `username` and `password` to their `.jenkins` file, as outlined in `README`.

**Outline of changes and expected behavior**

- With these changes, a basic authorization header is always sent to Jenkins.
- The credentials will default to empty strings, if not provided in the `.jenkins` file. 
- For unsecured Jenkins, the `.jenkins` file can contain no credentials, empty credentials, or invalid credentials.  The connection should succeed in any case.
- The `AUTHENTICATION NEEDED` error will be shown for both missing and incorrect credentials, when connecting to a secured Jenkins instance.  This will usually be a 401, rather than 403, since an auth header is always sent.

**Testing**

I tested this against an unsecured Jenkins instance (v1.647 running on localhost), and a secured Jenkins instance (v2.49 running remotely).  VSCode v1.12.2 was used for all testing.

**One Final Thought**

I considered adding a friendly reminder to the `README`, warning users not to accidentally check their plain-text passwords (via `.jenkins` file) into version control.  

I went back and forth on this.  You'd like to think this is common knowledge, and goes without saying, but perhaps it doesn't hurt to put out some orange safety/education pylons for the beginners in our ranks.  

In the end I didn't add any reminder/warning;  my reasoning was that I should defer to the maintainer's opinion on the (a) appropriateness/necessity and (b) verbiage of such a message.