### PR TITLE
Changed an example of .jenkins

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If you need _authentication_, just add `username` and `password_or_token` in the
 
 ```json
 {
-    "url": "http://127.0.0.1:8080/job/myproject",
+    "url": "http://127.0.0.1:8080/job/myproject/",
     "username": "jenkins_user",
     "password": "jenkins_password_or_token"
 }


### PR DESCRIPTION
The URL to a Jenkins project must end with "/". If it doesn't, we can't open a console page correctly because Jenkins Status combine specified URL, a build number and "/console" like this.
```TypeScript
opn(settings.url + status.buildNr.toString() + "/console");
```

I think this is not a bug, but an incorrect example of ".jenkins" file make new users confused. So I opened this pull request.