### PR TITLE
Add remote support (Closes #41)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
         "status",
         "multi-root ready"
     ],
+    "extensionKind": [
+        "ui",
+        "workspace"
+    ],
     "activationEvents": [
         "workspaceContains:.jenkins",
         "workspaceContains:.jenkinsrc.js",

--- a/src/JenkinsIndicator.ts
+++ b/src/JenkinsIndicator.ts
@@ -18,6 +18,10 @@ export class JenkinsIndicator {
     }
 
     public updateJenkinsStatus(settings: Setting[], registerCommand: (cmd: string, callback: () => void ) => void, deRegisterCommand: (cmd: string) => void): Setting[] {        
+        if (!settings) {
+            return;
+        }
+        
         let noNameCount = -1;
         this.settingNameToUrl = {};
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,15 +3,18 @@
 *  Licensed under the MIT License. See License.md in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import fs = require("fs");
-import path = require("path");
 import * as vscode from "vscode";
 import * as JenkinsIndicator from "./JenkinsIndicator";
 import { Setting } from "./setting";
 import { registerWhatsNew } from "./whats-new/commands";
 import { Container } from "./container";
+import { Uri } from "vscode";
+import { appendPath, readFileUri, uriExists } from "./fs";
 
-export function activate(context: vscode.ExtensionContext) {
+declare const __webpack_require__: typeof require;
+declare const __non_webpack_require__: typeof require;
+
+export async function activate(context: vscode.ExtensionContext) {
     
     Container.context = context;
 
@@ -20,7 +23,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     let currentSettings: Setting[];
     
-    if (hasJenkinsInAnyRoot()) {
+    if (await hasJenkinsInAnyRoot()) {
         createJenkinsIndicator(context);
         updateStatus();
     }
@@ -30,15 +33,15 @@ export function activate(context: vscode.ExtensionContext) {
     const dispUpdateStatus = vscode.commands.registerCommand("jenkins.updateStatus", () => updateStatus(true));
     context.subscriptions.push(dispUpdateStatus);
 
-    context.subscriptions.push(vscode.workspace.onDidChangeWorkspaceFolders(() => {
-        if (hasJenkinsInAnyRoot()) {
+    context.subscriptions.push(vscode.workspace.onDidChangeWorkspaceFolders(async () => {
+        if (await hasJenkinsInAnyRoot()) {
             createJenkinsIndicator(context);
         }
         updateStatus()}
     ));
 
     const dispOpenInJenkins = vscode.commands.registerCommand("jenkins.openInJenkins", async () => {
-        if (!hasJenkinsInAnyRoot()) {
+        if (!await hasJenkinsInAnyRoot()) {
             vscode.window.showWarningMessage("The project is not enabled for Jenkins. Missing .jenkins file.");
             return;
         } 
@@ -62,7 +65,7 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(dispOpenInJenkins);
 
     const dispOpenInJenkinsConsoleOutput = vscode.commands.registerCommand("jenkins.openInJenkinsConsoleOutput", async () => {
-        if (!hasJenkinsInAnyRoot()) {
+        if (!await hasJenkinsInAnyRoot()) {
             vscode.window.showWarningMessage("The project is not enabled for Jenkins. Missing .jenkins file.");
             return;
         } 
@@ -97,7 +100,7 @@ export function activate(context: vscode.ExtensionContext) {
     }
 
     async function updateStatus(showMessage?: boolean) {
-        if (showMessage && !hasJenkinsInAnyRoot()) {
+        if (showMessage && !await hasJenkinsInAnyRoot()) {
             vscode.window.showWarningMessage("The project is not enabled for Jenkins. Missing .jenkins file.");
             return;
         }
@@ -113,7 +116,7 @@ export function activate(context: vscode.ExtensionContext) {
         setInterval(() => updateStatus(), polling * 60000);
     }
 
-    function hasJenkinsInAnyRoot(): boolean {
+    async function hasJenkinsInAnyRoot(): Promise<boolean> {
 
         if (!vscode.workspace.workspaceFolders) {
             return false;
@@ -124,7 +127,7 @@ export function activate(context: vscode.ExtensionContext) {
         // for (let index = 0; index < vscode.workspace.workspaceFolders.length; index++) {
         for (const element of vscode.workspace.workspaceFolders) {
             // const element: vscode.WorkspaceFolder = vscode.workspace.workspaceFolders[index];
-            hasAny = !!getConfigPath(element.uri.fsPath);
+            hasAny = !!await getConfigPath(element.uri);
             if (hasAny) {
                 return hasAny;
             }
@@ -141,11 +144,11 @@ export function activate(context: vscode.ExtensionContext) {
         let settings: Setting[] = [];
         try {
             for (const element of vscode.workspace.workspaceFolders) {
-                const jenkinsSettingsPath = getConfigPath(element.uri.fsPath);            
-                if (jenkinsSettingsPath !== "") {
-                    let jenkinsSettings = await readSettings(jenkinsSettingsPath);
-                    jenkinsSettings = Array.isArray(jenkinsSettings) ? jenkinsSettings : [jenkinsSettings];
-                    settings = settings.concat(jenkinsSettings);
+                const jenkinsSettingsPath = await getConfigPath(element.uri);            
+                if (jenkinsSettingsPath.fsPath !== element.uri.fsPath) {
+                    const jenkinsSettings = await readSettings(jenkinsSettingsPath);
+                    const jenkinsSettings2 = Array.isArray(jenkinsSettings) ? jenkinsSettings : [jenkinsSettings];
+                    settings = settings.concat(...jenkinsSettings2);
                 }
             }       
         } catch (error) {
@@ -154,13 +157,14 @@ export function activate(context: vscode.ExtensionContext) {
         return settings;
     }
 
-    async function readSettings(jenkinsSettingsPath: string) {
-        if (jenkinsSettingsPath.endsWith(".jenkinsrc.js")) {
-            delete require.cache[require.resolve(jenkinsSettingsPath)];
-            return await require(jenkinsSettingsPath);
+    async function readSettings(jenkinsSettingsPath: Uri): Promise<string> {
+        if (jenkinsSettingsPath.fsPath.endsWith(".jenkinsrc.js")) {
+            const r = typeof __webpack_require__ === 'function' ? __non_webpack_require__ : require;
+             delete r.cache[r.resolve(jenkinsSettingsPath.fsPath)];
+             return await r(jenkinsSettingsPath.fsPath);
         } else {
-            const content = fs.readFileSync(jenkinsSettingsPath, "utf-8");
-            return JSON.parse(content);
+            const content = await readFileUri(jenkinsSettingsPath);
+            return content;
         }
     }
 
@@ -188,13 +192,13 @@ export function activate(context: vscode.ExtensionContext) {
         return;
     }
 
-    function getConfigPath(root: string): string {
-        if (fs.existsSync(path.join(root, ".jenkinsrc.js"))) {
-            return path.join(root, ".jenkinsrc.js");
-        } else if (fs.existsSync(path.join(root, ".jenkins"))) {
-            return path.join(root, ".jenkins");
+    async function getConfigPath(uri: Uri): Promise<Uri> {
+        if (await uriExists(appendPath(uri, ".jenkinsrc.js"))) {
+            return appendPath(uri, ".jenkinsrc.js");
+        } else if (uriExists(appendPath(uri, ".jenkins"))) {
+            return appendPath(uri, ".jenkins");
         }
-        return "";
+        return uri;
     }
 
     function createWatcher(folder: vscode.WorkspaceFolder) {

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Alessandro Fragnani. All rights reserved.
+*  Licensed under the MIT License. See License.md in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import path = require("path");
+import { Uri, workspace } from "vscode";
+
+export function appendPath(uri: Uri, pathSuffix: string): Uri {
+    const pathPrefix = uri.path.endsWith("/") ? uri.path : `${uri.path}/`;
+    const filePath = `${pathPrefix}${pathSuffix}`;
+
+    return uri.with({
+        path: filePath
+    });
+}
+
+export function uriJoin(uri: Uri, ...paths: string[]): string {
+    return path.join(uri.fsPath, ...paths);
+}
+
+export async function uriExists(uri: Uri): Promise<boolean> {
+    
+    try {
+        await workspace.fs.stat(uri);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+export async function readFile(filePath: string): Promise<string> {
+    const bytes = await workspace.fs.readFile(Uri.parse(filePath));
+    return JSON.parse(Buffer.from(bytes).toString('utf8'));
+}
+
+export async function readFileUri(uri: Uri): Promise<string> {
+    const bytes = await workspace.fs.readFile(uri);
+    return JSON.parse(Buffer.from(bytes).toString('utf8'));
+}

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -1,0 +1,13 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Alessandro Fragnani. All rights reserved.
+*  Licensed under the MIT License. See License.md in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { Uri } from "vscode";
+
+export const REMOTE_PREFIX = "vscode-remote";
+export const VIRTUAL_WORKSPACE_PREFIX = "vscode-vfs";
+
+export function isRemoteUri(uri: Uri): boolean {
+    return uri.scheme === REMOTE_PREFIX || uri.scheme === VIRTUAL_WORKSPACE_PREFIX;
+}


### PR DESCRIPTION
Closes #41 

Using #76 snippet for properly load `.jenkinsrc.js` on remotes (if the extension is installed on remotes)