### PR TITLE
Remove unused class JenkinsIndicatorController

### DIFF
--- a/src/JenkinsIndicator.ts
+++ b/src/JenkinsIndicator.ts
@@ -156,17 +156,3 @@ export class JenkinsIndicator {
         }
     }
 }
-
-export class JenkinsIndicatorController {
-
-    private jenkinsIndicator: JenkinsIndicator;
-    private disposable: vscode.Disposable;
-
-    constructor(indicator: JenkinsIndicator) {
-        this.jenkinsIndicator = indicator;
-    }
-
-    public dispose() {
-        this.disposable.dispose();
-    }
-}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,7 +20,6 @@ export async function activate(context: vscode.ExtensionContext) {
     Container.context = context;
 
     let jenkinsIndicator: JenkinsIndicator.JenkinsIndicator;
-    let jenkinsController: JenkinsIndicator.JenkinsIndicatorController; 
 
     let currentSettings: Setting[];
     
@@ -99,8 +98,6 @@ export async function activate(context: vscode.ExtensionContext) {
         }
         
         jenkinsIndicator = new JenkinsIndicator.JenkinsIndicator();
-        jenkinsController = new JenkinsIndicator.JenkinsIndicatorController(jenkinsIndicator);
-        aContext.subscriptions.push(jenkinsController);
         aContext.subscriptions.push(jenkinsIndicator);
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from "vscode";
-import * as JenkinsIndicator from "./JenkinsIndicator";
+import { JenkinsIndicator } from "./JenkinsIndicator";
 import { Setting } from "./setting";
 import { registerWhatsNew } from "./whats-new/commands";
 import { Container } from "./container";
@@ -19,7 +19,7 @@ export async function activate(context: vscode.ExtensionContext) {
     
     Container.context = context;
 
-    let jenkinsIndicator: JenkinsIndicator.JenkinsIndicator;
+    let jenkinsIndicator: JenkinsIndicator;
 
     let currentSettings: Setting[];
     
@@ -97,7 +97,7 @@ export async function activate(context: vscode.ExtensionContext) {
             return;
         }
         
-        jenkinsIndicator = new JenkinsIndicator.JenkinsIndicator();
+        jenkinsIndicator = new JenkinsIndicator();
         aContext.subscriptions.push(jenkinsIndicator);
     }
 


### PR DESCRIPTION
The class JenkinsIndicatorController is not really used. This PR removes the class and the traces of its use.